### PR TITLE
Added to and fixed formatting to ecosystem page.

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -3106,7 +3106,7 @@
 	              <div class="d-flex flex-sm-row flex-column justify-content-between p-md-1">
 	                <div class="d-flex flex-sm-row flex-column">
 	                  <div class="align-self-center">
-	                    <img src="images/Ecosystem/anyhedge.svg" alt="Any hedge logo" class="card-img-standard me-0 me-sm-3 mb-3 mb-sm-0">
+	                    <img src="images/Ecosystem/anyhedge.svg" alt="AnyHedge logo" class="card-img-standard me-0 me-sm-3 mb-3 mb-sm-0">
 	                  </div>
 	                  <div>
 	                    <h4 class="text-break">AnyHedge</h4>

--- a/ecosystem.html
+++ b/ecosystem.html
@@ -3121,6 +3121,32 @@
 	          </div>
 	        </div>
 	        <div class="col mb-4">
+	          <div class="card" data-header="Technical, DevTool">
+	            <div class="card-header d-flex justify-content-between align-items-center">
+	            	<div class="fs-6">Development</div>
+	            </div>
+	            <div class="card-body text-center text-sm-start">
+	              <div class="d-flex flex-sm-row flex-column justify-content-between p-md-1">
+	                <div class="d-flex flex-sm-row flex-column">
+	                  <div class="align-self-center">
+	                    <img src="images/Ecosystem/bitcoincash.svg" alt="cashlab logo" class="card-img-standard me-0 me-sm-3 mb-3 mb-sm-0">
+	                  </div>
+	                  <div>
+	                    <h4 class="text-break">cashlab</h4>
+	                    <p class="mb-0 fs-6">cashlab is a set of high level packages to do defi in the Bitcoin Cash network. Written in TypeScript compatible with node.js and web runtime environments.</p>
+	                  </div>
+	                </div>
+	                <div class="align-self-center ms-0 ms-sm-3 mt-3 mt-sm-0">
+	                  <a href="https://github.com/hosseinzoda/cashlab" class="btn btn-lg btn-primary" aria-label="Primary link">Visit</a>
+	                </div>
+	              </div>
+	            </div>
+	            <div class="card-footer">
+	            	<a href="https://github.com/hosseinzoda/cashlab" class="fs-5r text-secondary me-2" aria-label="link to Github"><i class="bi bi-github"></i></a>
+	            </div>
+	          </div>
+	        </div>
+	        <div class="col mb-4">
 	          <div class="card" data-header="POS, Tool">
 	            <div class="card-header d-flex justify-content-between align-items-center">
 	            	<div class="fs-6">Point of Sale</div>


### PR DESCRIPTION
Fixed formatting for "AnyHedge" in the AnyHedge image description.
Intentionally kept "cashlab" lowercased as that's how it appears to be intentionally written on github.