### PR TITLE
Add Vultisig wallet to ecosystem page

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -3318,7 +3318,7 @@
 		            <img src="images/Ecosystem/vultisig.svg" alt="Vultisig logo" class="card-img-standard ecosystemCircle me-sm-3 mb-3 mb-sm-0">
 		            <div class="flex-grow-1">
 		              <h4 class="text-break">Vultisig</h4>
-		              <p class="mb-0 fs-6">No seed phrase, ever. Key shares live on your own devices; a threshold signs. A self-custodial MPC wallet, multi-chain with Bitcoin Cash support, on iOS, Android, desktop, and browser.</p>
+		              <p class="mb-0 fs-6">No seed phrase to lose. Vultisig protects your crypto across your own devices, so only you can move your money. Works with 30+ coins including Bitcoin Cash, on iPhone, Android, desktop, and browser. Free and open-source.</p>
 		            </div>
 		            <a href="https://vultisig.com" class="btn btn-lg btn-primary align-self-center ms-sm-3 mt-3 mt-sm-0" aria-label="Primary link">Visit</a>
 		          </div>

--- a/ecosystem.html
+++ b/ecosystem.html
@@ -3312,6 +3312,28 @@
 		    </div>
 		    <div class="col mb-4">
 		      <div class="card" data-header="Wallet">
+		        <div class="card-header fs-6">Wallet</div>
+		        <div class="card-body text-center text-sm-start">
+		          <div class="d-flex flex-sm-row flex-column justify-content-between p-md-1">
+		            <img src="images/Ecosystem/vultisig.svg" alt="Vultisig logo" class="card-img-standard ecosystemCircle me-sm-3 mb-3 mb-sm-0">
+		            <div class="flex-grow-1">
+		              <h4 class="text-break">Vultisig</h4>
+		              <p class="mb-0 fs-6">A seedless, self-custodial MPC wallet with no seed phrase — key shares are split across your own devices. Multi-chain with BCH support, available on iOS, Android, desktop, and browser.</p>
+		            </div>
+		            <a href="https://vultisig.com" class="btn btn-lg btn-primary align-self-center ms-sm-3 mt-3 mt-sm-0" aria-label="Primary link">Visit</a>
+		          </div>
+		        </div>
+		      	<div class="card-footer">
+		      		<a href="https://github.com/vultisig" class="fs-5r text-secondary me-2" aria-label="link to Github"><i class="bi bi-github"></i></a>
+		      		<a href="https://x.com/vultisig" class="fs-5r text-secondary me-2" aria-label="link to X (Twitter)"><i class="bi bi-twitter-x"></i></a>
+		      		<a href="https://t.me/vultisig" class="fs-5r text-secondary me-2" aria-label="link to Telegram"><i class="bi bi-telegram"></i></a>
+		      		<a href="https://discord.gg/thq64eaYVN" class="fs-5r text-secondary me-2" aria-label="link to Discord"><i class="bi bi-discord"></i></a>
+		      		<a href="https://youtube.com/@Vultisig" class="fs-5r text-secondary me-2" aria-label="link to YouTube"><i class="bi bi-youtube"></i></a>
+		      	</div>
+		      </div>
+		    </div>
+		    <div class="col mb-4">
+		      <div class="card" data-header="Wallet">
 		        <div class="card-header d-flex justify-content-between align-items-center">
 		        	<div class="fs-6">Wallet</div>
 		        	<button class="btn btn-sm btn-outline-primary fs-7" disabled>Bitcoin.com</button>

--- a/ecosystem.html
+++ b/ecosystem.html
@@ -3318,7 +3318,7 @@
 		            <img src="images/Ecosystem/vultisig.svg" alt="Vultisig logo" class="card-img-standard ecosystemCircle me-sm-3 mb-3 mb-sm-0">
 		            <div class="flex-grow-1">
 		              <h4 class="text-break">Vultisig</h4>
-		              <p class="mb-0 fs-6">A seedless, self-custodial MPC wallet with no seed phrase — key shares are split across your own devices. Multi-chain with BCH support, available on iOS, Android, desktop, and browser.</p>
+		              <p class="mb-0 fs-6">No seed phrase, ever. Key shares live on your own devices; a threshold signs. A self-custodial MPC wallet, multi-chain with Bitcoin Cash support, on iOS, Android, desktop, and browser.</p>
 		            </div>
 		            <a href="https://vultisig.com" class="btn btn-lg btn-primary align-self-center ms-sm-3 mt-3 mt-sm-0" aria-label="Primary link">Visit</a>
 		          </div>

--- a/images/Ecosystem/vultisig.svg
+++ b/images/Ecosystem/vultisig.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 1024 1024" fill="none">
+<rect width="1024" height="1024" rx="512" fill="#061B3A" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" fill="url(#paint0_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" fill="url(#paint1_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" fill="url(#paint2_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" fill="url(#paint3_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" fill="url(#paint4_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" fill="url(#paint5_linear_6897_19996)" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" stroke="url(#paint6_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" stroke="url(#paint7_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" stroke="url(#paint8_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" stroke="url(#paint9_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" stroke="url(#paint10_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" stroke="url(#paint11_linear_6897_19996)" />
+<defs>
+<linearGradient id="paint0_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint1_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint2_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint3_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint4_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint5_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint6_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint7_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint8_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint9_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint10_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint11_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
Adds a Wallet card for [Vultisig](https://vultisig.com) to the ecosystem page, placed alongside the other multi-coin wallets (Cake, Stack).

Vultisig is a non-custodial, open-source MPC wallet: key shares are split across the user's own devices using threshold signatures, so there is no seed phrase. It supports Bitcoin Cash natively (send/receive, `bitcoincash:` addresses) alongside 30+ chains, on iOS, Android, macOS, Windows, Linux, and as a browser extension.

- Card follows the `ECOSYSTEM-PR-GUIDELINES.md` format (single image, `card-img-standard` + `ecosystemCircle`).
- Logo `images/Ecosystem/vultisig.svg` is an SVG, 4.4kb (< 30kb target), dark (non-white/black) background.
- All social links verified from the official site footer.

## receipts

no runtime changes (static HTML card + SVG asset). SVG validated: `python3 -m xml.dom.minidom` parses `images/Ecosystem/vultisig.svg` (4411 bytes). Social/GitHub links pulled from vultisig.com footer; BCH support verified in the Vultisig SDK (`Chain.BitcoinCash`, native `bitcoincash:` address derivation).